### PR TITLE
[Feat] 영상 트림, 자동 스크롤 로직 구현

### DIFF
--- a/HongAndJerry/HongAndJerry/Source/Extension/Example++.swift
+++ b/HongAndJerry/HongAndJerry/Source/Extension/Example++.swift
@@ -1,8 +1,0 @@
-//
-//  Example++.swift
-//  HongAndJerry
-//
-//  Created by Rama on 7/16/25.
-//
-
-import Foundation

--- a/HongAndJerry/HongAndJerry/Source/Extension/VideoSegment++.swift
+++ b/HongAndJerry/HongAndJerry/Source/Extension/VideoSegment++.swift
@@ -1,0 +1,41 @@
+//
+//  VideoSegment++.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/18/25.
+//
+
+import AVKit
+
+#if DEBUG
+extension VideoSegment {
+   static func mock(
+       url: String = "mock://video/segment.mp4",
+       sourceDuration: TimeInterval = 60,
+       startTime: TimeInterval = 0,
+       trimmedDuration: TimeInterval = 30
+   ) -> VideoSegment {
+       let mockSource = VideoSource.mock(
+           url: url,
+           duration: sourceDuration
+       )
+       
+       return VideoSegment(
+           source: mockSource,
+           startTime: CMTime(seconds: startTime, preferredTimescale: 600),
+           trimmedDuration: CMTime(seconds: trimmedDuration, preferredTimescale: 600)
+       )
+   }
+   
+   static func mockList(count: Int = 3) -> [VideoSegment] {
+       (0..<count).map { index in
+           mock(
+               url: "mock://video/segment\(index + 1).mp4",
+               sourceDuration: Double(40 + index * 20),
+               startTime: Double(index * 2),
+               trimmedDuration: Double(15 + index * 5)
+           )
+       }
+   }
+}
+#endif

--- a/HongAndJerry/HongAndJerry/Source/Extension/VideoSource++.swift
+++ b/HongAndJerry/HongAndJerry/Source/Extension/VideoSource++.swift
@@ -1,0 +1,25 @@
+//
+//  VideoSource++.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/18/25.
+//
+
+import AVKit
+
+#if DEBUG
+extension VideoSource {
+   static func mock(
+       url: String = "mock://video/source1.mp4",
+       duration: TimeInterval = 60
+   ) -> VideoSource {
+       let mockURL = URL(string: url)!
+       let mockAsset = AVURLAsset(url: mockURL)
+       return VideoSource(
+           asset: mockAsset,
+           url: url,
+           duration: CMTime(seconds: duration, preferredTimescale: 600)
+       )
+   }
+}
+#endif

--- a/HongAndJerry/HongAndJerry/Source/Model/VideoSegment.swift
+++ b/HongAndJerry/HongAndJerry/Source/Model/VideoSegment.swift
@@ -5,4 +5,11 @@
 //  Created by Rama on 7/16/25.
 //
 
-import Foundation
+import AVKit
+
+struct VideoSegment {
+    let id: UUID = UUID() 
+    let source: VideoSource
+    let startTime: CMTime
+    let trimmedDuration: CMTime
+}

--- a/HongAndJerry/HongAndJerry/Source/Model/VideoSource.swift
+++ b/HongAndJerry/HongAndJerry/Source/Model/VideoSource.swift
@@ -1,0 +1,25 @@
+//
+//  VideoSource.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/18/25.
+//
+
+import AVKit
+
+struct VideoSource: Identifiable {
+    let id: UUID = UUID()
+    let asset: AVAsset
+    let url: String
+    let duration: CMTime
+    
+    init(
+        asset: AVAsset,
+        url: String,
+        duration: CMTime
+    ) {
+        self.asset = asset
+        self.url = url
+        self.duration = duration
+    }
+}

--- a/HongAndJerry/HongAndJerry/Source/Service/EditOperations/EditOperation.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/EditOperations/EditOperation.swift
@@ -1,0 +1,12 @@
+//
+//  EditOperation.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/17/25.
+//
+
+protocol EditOperation {
+    func apply(on segments: [VideoSegment]) async throws -> EditResult
+}
+
+

--- a/HongAndJerry/HongAndJerry/Source/Service/EditOperations/TrimOperation.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/EditOperations/TrimOperation.swift
@@ -8,66 +8,92 @@
 import AVKit
 import SwiftUI
 
-class TrimOperation: EditOperation {
-    var isDragging: Bool = false
-    var handleType: HandleType = .none
+final class TrimOperation: EditOperation {
+    var trackWidth: CGFloat = 0
+    private var isDragging: Bool = false
+    private var handleType: HandleType = .none
+    private(set) var screenWidth: CGFloat = 0
     
-    var screenWidth: CGFloat = 0
-    var oldLeftHandleOffset: CGFloat = 0
-    var oldRightHandleOffset: CGFloat = 0
-    var leftHandleOffset: CGFloat = 0
-    var rightHandleOffset: CGFloat = 0
+    var scrollOffset: CGFloat = 0
+    var scrollTargetOffset: CGFloat = 0
+    private var oldLeftHandleOffset: CGFloat = 0
+    private var oldRightHandleOffset: CGFloat = 0
+    private var newLeftHandleOffset: CGFloat = 0
+    private var newRightHandleOffset: CGFloat = 0
+    private var dragDirection: DragDirection = .none
     
-    let pixelsPerSecond: CGFloat = 25.0
-    let trimMinimumDutarion: Double = 1.0
-    var trackMinimumPixel: CGFloat {
-        pixelsPerSecond * trimMinimumDutarion
+    private let pixelsPerSecond: CGFloat = 25.0
+    private let trimMinimumDurarion: Double = 1.0
+    private var trackMinimumPixel: CGFloat {
+        pixelsPerSecond * trimMinimumDurarion
     }
     
     var mockSegments: [VideoSegment] {
         VideoSegment.mockList()
     }
     
+    /// 비디오 세그먼트에 트림 작업을 적용
+    /// - Parameter segments: 트림할 비디오 세그먼트 배열
+    /// - Returns: 트림된 결과를 담은 EditResult
     func apply(on segments: [VideoSegment]) async throws -> EditResult {
         return .segmentsUpdated(mockSegments)
     }
     
-    func dragHandle(type: HandleType, translation: CGFloat) {
+    /// 핸들 드래그 동작을 처리
+    /// - Parameters:
+    ///   - type: 드래그하는 핸들의 타입 (left/right)
+    ///   - translation: 드래그 이동량
+
+    func dragHandle(
+        type: HandleType,
+        translation: CGFloat
+    ) {
         startDrag(type: type)
         
         let newOffset = calculateHandleOffset(
             type: type,
             translation: translation
         )
+        
         setHandleOffset(
             type: type,
             offset: newOffset
         )
+        
+        startAutoScroll()
     }
     
+    /// 드래그 시작 시 초기 상태를 설정
+    /// - Parameter type: 드래그하는 핸들의 타입
     private func startDrag(type: HandleType) {
         guard !isDragging else { return }
         
         isDragging = true
         handleType = type
-        oldLeftHandleOffset = leftHandleOffset
-        oldRightHandleOffset = rightHandleOffset
+        oldLeftHandleOffset = newLeftHandleOffset
+        oldRightHandleOffset = newRightHandleOffset
     }
     
-    private func endDrag() {
+    /// 드래그 종료 시 상태를 초기화합니다
+    func endDrag() {
         isDragging = false
         handleType = .none
     }
     
+    /// 핸들 드래그 후의 새로운 오프셋 값을 계산
+    /// - Parameters:
+    ///   - type: 핸들 타입
+    ///   - translation: 드래그 이동량
+    /// - Returns: 계산된 새로운 오프셋 값
     private func calculateHandleOffset(
         type: HandleType,
         translation: CGFloat
     ) -> CGFloat {
         switch type {
-        case .leftHandle:
+        case .left:
             return oldLeftHandleOffset + translation
             
-        case .rightHandle:
+        case .right:
             return oldRightHandleOffset + translation
             
         case .none:
@@ -75,17 +101,58 @@ class TrimOperation: EditOperation {
         }
     }
     
-    private func setHandleOffset(type: HandleType, offset: CGFloat) {
+    /// 핸들의 오프셋을 제약 조건에 맞게 설정
+    /// - Parameters:
+    ///   - type: 핸들 타입
+    ///   - offset: 설정할 오프셋 값
+    private func setHandleOffset(
+        type: HandleType,
+        offset: CGFloat
+    ) {
         switch type {
-        case .leftHandle:
-            leftHandleOffset = max(0, min(offset, rightHandleOffset - trackMinimumPixel))
+        case .left:
+            newLeftHandleOffset = max(0, min(offset, newRightHandleOffset - trackMinimumPixel))
             
-        case .rightHandle:
-            rightHandleOffset = max(0, min(offset, rightHandleOffset - trackMinimumPixel))
+        case .right:
+            newRightHandleOffset = max(newLeftHandleOffset + trackMinimumPixel, min(newRightHandleOffset, screenWidth))
             
         case .none:
             break
         }
     }
-
+    
+    /// 핸들 위치에 따라 자동 스크롤 방향을 결정
+    /// - Parameter handleOffset: 현재 핸들의 스크린 상 오프셋 위치
+    private func setDragDirection(handleOffset: CGFloat) {
+        let leftScrollPoint = scrollOffset + (screenWidth * 0.25)
+        let rightScrollPoint = scrollOffset + (screenWidth * 0.75)
+        
+        if handleOffset <= leftScrollPoint {
+            dragDirection = .left
+        } else if handleOffset >= rightScrollPoint {
+            dragDirection = .right
+        } else {
+            dragDirection = .none
+        }
+    }
+    
+    /// 핸들이 화면 가장자리에 있을 때 자동 스크롤을 시작
+    private func startAutoScroll() {
+        guard isDragging && dragDirection != .none else { return }
+        
+        if handleType == .left {
+            scrollTargetOffset = scrollOffset
+        } else if handleType == .right {
+            scrollTargetOffset = scrollOffset + screenWidth
+        }
+        
+        // TODO: View 구현 후 추가할 내용
+//        autoScrollTimer?.invalidate()
+//        autoScrollTimer = Timer.scheduledTimer(
+//            withTimeInterval: 0.016,
+//            repeats: true
+//        ) { _ in
+//            self.onAutoScroll?()
+        
+    }
 }

--- a/HongAndJerry/HongAndJerry/Source/Service/EditOperations/TrimOperation.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/EditOperations/TrimOperation.swift
@@ -1,0 +1,91 @@
+//
+//  TrimOperation.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/17/25.
+//
+
+import AVKit
+import SwiftUI
+
+class TrimOperation: EditOperation {
+    var isDragging: Bool = false
+    var handleType: HandleType = .none
+    
+    var screenWidth: CGFloat = 0
+    var oldLeftHandleOffset: CGFloat = 0
+    var oldRightHandleOffset: CGFloat = 0
+    var leftHandleOffset: CGFloat = 0
+    var rightHandleOffset: CGFloat = 0
+    
+    let pixelsPerSecond: CGFloat = 25.0
+    let trimMinimumDutarion: Double = 1.0
+    var trackMinimumPixel: CGFloat {
+        pixelsPerSecond * trimMinimumDutarion
+    }
+    
+    var mockSegments: [VideoSegment] {
+        VideoSegment.mockList()
+    }
+    
+    func apply(on segments: [VideoSegment]) async throws -> EditResult {
+        return .segmentsUpdated(mockSegments)
+    }
+    
+    func dragHandle(type: HandleType, translation: CGFloat) {
+        startDrag(type: type)
+        
+        let newOffset = calculateHandleOffset(
+            type: type,
+            translation: translation
+        )
+        setHandleOffset(
+            type: type,
+            offset: newOffset
+        )
+    }
+    
+    private func startDrag(type: HandleType) {
+        guard !isDragging else { return }
+        
+        isDragging = true
+        handleType = type
+        oldLeftHandleOffset = leftHandleOffset
+        oldRightHandleOffset = rightHandleOffset
+    }
+    
+    private func endDrag() {
+        isDragging = false
+        handleType = .none
+    }
+    
+    private func calculateHandleOffset(
+        type: HandleType,
+        translation: CGFloat
+    ) -> CGFloat {
+        switch type {
+        case .leftHandle:
+            return oldLeftHandleOffset + translation
+            
+        case .rightHandle:
+            return oldRightHandleOffset + translation
+            
+        case .none:
+            return 0
+        }
+    }
+    
+    private func setHandleOffset(type: HandleType, offset: CGFloat) {
+        switch type {
+        case .leftHandle:
+            leftHandleOffset = max(0, min(offset, rightHandleOffset - trackMinimumPixel))
+            
+        case .rightHandle:
+            rightHandleOffset = max(0, min(offset, rightHandleOffset - trackMinimumPixel))
+            
+        case .none:
+            break
+        }
+    }
+
+}

--- a/HongAndJerry/HongAndJerry/Source/Type/DragDirection.swift
+++ b/HongAndJerry/HongAndJerry/Source/Type/DragDirection.swift
@@ -1,0 +1,12 @@
+//
+//  DragDirection.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/20/25.
+//
+
+enum DragDirection {
+    case left
+    case right
+    case none
+}

--- a/HongAndJerry/HongAndJerry/Source/Type/EditResult.swift
+++ b/HongAndJerry/HongAndJerry/Source/Type/EditResult.swift
@@ -5,14 +5,10 @@
 //  Created by Rama on 7/16/25.
 //
 
-import SwiftUI
+import Foundation
 
-struct EditResult: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
-}
-
-#Preview {
-    EditResult()
+enum EditResult {
+    case segmentsUpdated([VideoSegment])
+    case exportCompleted(URL)
+    case noChange
 }

--- a/HongAndJerry/HongAndJerry/Source/Type/HandleType.swift
+++ b/HongAndJerry/HongAndJerry/Source/Type/HandleType.swift
@@ -6,7 +6,7 @@
 //
 
 enum HandleType {
-    case leftHandle
-    case rightHandle
+    case left
+    case right
     case none
 }

--- a/HongAndJerry/HongAndJerry/Source/Type/HandleType.swift
+++ b/HongAndJerry/HongAndJerry/Source/Type/HandleType.swift
@@ -1,0 +1,12 @@
+//
+//  HandleType.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/17/25.
+//
+
+enum HandleType {
+    case leftHandle
+    case rightHandle
+    case none
+}


### PR DESCRIPTION
## 🐱 **작업한 내용, 스크린샷**
- TrimOperation에 해당하는 트리밍 로직을 구현했습니다.
- VideoSegment의 MockData를 쉽게 생성할 수 있는 Extension을 구현했습니다. 사용 예시는 아래에..

## 🐭 **참고 사항**

```
class VideoViewModel: ObservableObject {
   @Published var segments: [VideoSegment] = []
   
   /// 3개의 MockData 생성 예시
   func loadMockData() {
       segments = VideoSegment.mockList(count: 3)
       print("Mock 데이터 로드 완료: \(segments.count)개")
   }
   
   /// 단일 MockData 추가
   func loadSingleMockData() {
       let newSegment = VideoSegment.mock(
           url: "mock://video/new_segment.mp4",
           sourceDuration: 45,
           startTime: 5,
           trimmedDuration: 30
       )
       segments.append(newSegment)
   }
}
```
resolved #4 