### PR TITLE
[feat] PHAsset 타입의 비디오를 Crop하는 기능

### DIFF
--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/AssetError.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/AssetError.swift
@@ -1,0 +1,13 @@
+//
+//  AssetError.swift
+//  HongAndJerry
+//
+//  Created by Soop on 7/23/25.
+//
+
+import Foundation
+
+enum AssetError: Error {
+    case infoNotFound
+    case assetNotFound
+}

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/Crop.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/Crop.swift
@@ -6,8 +6,10 @@
 //
 
 import SwiftUI
+import Photos
 
 struct Crop {
+    let video: PHAsset
     let localIdentifier: String // PHAsset의 id
     var cropRect: CGRect        // Crop할 영역
     var thumbnail: UIImage

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropView.swift
@@ -33,6 +33,7 @@ struct CropView: View {
                     router.push(screen: .videoEditView([]))
                 }
             }
+            .padding(.horizontal, 16)
             .onAppear {
                 viewModel.send(.loadThumbnail)
             }
@@ -89,8 +90,8 @@ struct CropView: View {
                                         viewModel.updateCropRect(at: videoIndex, rect: initialRect)
                                     }
                                 }
-                                .onChange(of: geometry.size) {
-                                    self.imageViewSize = $0
+                                .onChange(of: geometry.size) { oldValue, newValue in
+                                    self.imageViewSize = newValue
                                 }
                         }
                     }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropViewModel.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropViewModel.swift
@@ -59,7 +59,7 @@ extension CropViewModel {
             let thumbnail = await loadSingleThumbnail(for: video)
             if let thumbnail = thumbnail {
                 thumbnails[video.localIdentifier] = thumbnail
-                crops.append(Crop(localIdentifier: video.localIdentifier, cropRect: .init(x: 0, y: 0, width: 100, height: 100), thumbnail: thumbnail))
+                crops.append(Crop(video: video, localIdentifier: video.localIdentifier, cropRect: .init(x: 0, y: 0, width: 100, height: 100), thumbnail: thumbnail))
             }
         }
         
@@ -130,5 +130,9 @@ extension CropViewModel {
         let y = (imageSize.height - cropHeight) / 2
         
         return CGRect(x: x, y: y, width: cropWidth, height: cropHeight)
+    }
+    
+    func cropVideos() -> [AVAsset] {
+        return []
     }
 }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/PHImageManager.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/PHImageManager.swift
@@ -1,0 +1,94 @@
+//
+//  PHImageManager.swift
+//  HongAndJerry
+//
+//  Created by Soop on 7/23/25.
+//
+
+import Photos
+import AVFoundation
+
+extension PHImageManager {
+    
+    /// PHAsset을 비동기로 AVAsset으로 변환.
+    func requestAVAssetAsync(
+        for asset: PHAsset,
+        options: PHVideoRequestOptions? = nil
+    ) async throws -> AVAsset {
+        try await withCheckedThrowingContinuation { continuation in
+            self.requestAVAsset(forVideo: asset, options: options) { avAsset, audioMix, info in
+                
+                // 에러 처리: info에 에러가 있을 경우 throw
+                if let error = info?[PHImageErrorKey] as? Error {
+                    continuation.resume(throwing: AssetError.infoNotFound)
+                    return
+                }
+                
+                // AVAsset 반환 성공
+                if let avAsset = avAsset {
+                    continuation.resume(returning: avAsset)
+                } else {
+                    continuation.resume(throwing: AssetError.assetNotFound)
+                }
+            }
+        }
+    }
+    
+    func cropVideos(_ crops: [Crop]) async throws {
+        
+        for crop in crops {
+            let video  = try await self.requestAVAssetAsync(for: crop.video)        // AVAsset 타입의 비디오
+            let videoSize = try await getVideoSize(from: video)                     // 비디오의 실제 사이즈
+            let actualCropRect = self.convertThumbnailRectToVideoRect(thumbnailRect: crop.cropRect, thumbnailSize: crop.thumbnail.size, videoSize: videoSize)                           // 실제 크롭 영역
+            
+            
+        }
+        
+    }
+    
+    func getVideoSize(from asset: AVAsset) async throws -> CGSize {
+        guard let track = try? await asset.loadTracks(withMediaType: .video).first else {
+            throw AssetError.assetNotFound
+            
+        }
+        
+        let size = try await track.load(.naturalSize).applying(track.load(.preferredTransform))
+        
+        return CGSize(width: abs(size.width), height: abs(size.height))
+    }
+    
+    func convertThumbnailRectToVideoRect(
+        thumbnailRect: CGRect,
+        thumbnailSize: CGSize,
+        videoSize: CGSize
+    ) -> CGRect {
+        // 썸네일과 실제 비디오의 비율 계산
+        let scaleX = videoSize.width / thumbnailSize.width
+        let scaleY = videoSize.height / thumbnailSize.height
+        
+        // CGRect를 실제 비디오 좌표로 변환
+        let videoRect = CGRect(
+            x: thumbnailRect.origin.x * scaleX,
+            y: thumbnailRect.origin.y * scaleY,
+            width: thumbnailRect.width * scaleX,
+            height: thumbnailRect.height * scaleY
+        )
+        
+        return videoRect
+    }
+    
+    func makeCroppedVideo(crop: CGRect, asset: AVAsset) async throws -> AVMutableVideoComposition {
+        let videoComposition = try await AVMutableVideoComposition.videoComposition(with: asset) { request in
+            let cropFilter = CIFilter(name: "CICrop")!
+            cropFilter.setValue(request.sourceImage, forKey: kCIInputImageKey)
+            cropFilter.setValue(CIVector(cgRect: crop), forKey: "inputRectanlge")
+            let cropped = cropFilter.outputImage!
+            let translated = cropped.transformed(by: CGAffineTransform(translationX: -crop.origin.x, y: -crop.origin.y))
+            request.finish(with: translated, context: nil)
+        }
+        
+        videoComposition.renderSize = crop.size
+        
+        return videoComposition
+    }
+}

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/PHImageManager.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/PHImageManager.swift
@@ -35,13 +35,10 @@ extension PHImageManager {
     }
     
     func cropVideos(_ crops: [Crop]) async throws {
-        
         for crop in crops {
             let video  = try await self.requestAVAssetAsync(for: crop.video)        // AVAsset 타입의 비디오
             let videoSize = try await getVideoSize(from: video)                     // 비디오의 실제 사이즈
             let actualCropRect = self.convertThumbnailRectToVideoRect(thumbnailRect: crop.cropRect, thumbnailSize: crop.thumbnail.size, videoSize: videoSize)                           // 실제 크롭 영역
-            
-            
         }
         
     }
@@ -49,7 +46,6 @@ extension PHImageManager {
     func getVideoSize(from asset: AVAsset) async throws -> CGSize {
         guard let track = try? await asset.loadTracks(withMediaType: .video).first else {
             throw AssetError.assetNotFound
-            
         }
         
         let size = try await track.load(.naturalSize).applying(track.load(.preferredTransform))


### PR DESCRIPTION
## 🐱 **작업한 내용, 스크린샷**
일단 비디오 타입 전환 함수들을 만들었습니다...
1. PHAsset과 CGRect을 받아온다.
 2. PHAsset를 AVAsset으로 변환한다.
 ```swift
    func requestAVAssetAsync(
        for asset: PHAsset,
        options: PHVideoRequestOptions? = nil
    ) async throws -> AVAsset {
        try await withCheckedThrowingContinuation { continuation in
            self.requestAVAsset(forVideo: asset, options: options) { avAsset, audioMix, info in
                
                // 에러 처리: info에 에러가 있을 경우 throw
                if let error = info?[PHImageErrorKey] as? Error {
                    continuation.resume(throwing: AssetError.infoNotFound)
                    return
                }
                
                // AVAsset 반환 성공
                if let avAsset = avAsset {
                    continuation.resume(returning: avAsset)
                } else {
                    continuation.resume(throwing: AssetError.assetNotFound)
                }
            }
        }
    }
````

 3. 비디오의 실제 사이즈를 가져와서, 사용자가 입력한 CGRect을 스크린 스케일과 비디오 화질에 맞게 재조정 한다. 
 ```swift
    func getVideoSize(from asset: AVAsset) async throws -> CGSize {
        guard let track = try? await asset.loadTracks(withMediaType: .video).first else {
            throw AssetError.assetNotFound
            
        }
        
        let size = try await track.load(.naturalSize).applying(track.load(.preferredTransform))
        
        return CGSize(width: abs(size.width), height: abs(size.height))
    }
````

```swift
    func convertThumbnailRectToVideoRect(
        thumbnailRect: CGRect,
        thumbnailSize: CGSize,
        videoSize: CGSize
    ) -> CGRect {
        // 썸네일과 실제 비디오의 비율 계산
        let scaleX = videoSize.width / thumbnailSize.width
        let scaleY = videoSize.height / thumbnailSize.height
        
        // CGRect를 실제 비디오 좌표로 변환
        let videoRect = CGRect(
            x: thumbnailRect.origin.x * scaleX,
            y: thumbnailRect.origin.y * scaleY,
            width: thumbnailRect.width * scaleX,
            height: thumbnailRect.height * scaleY
        )
        
        return videoRect
    }
```
 
 4. 2와 3에서 받은 AVAsset과 CGRect으로 VideoMutableCompotion을 만든다.
     4-1. 이때 CIFilter로 비디오에 Crop 효과를 적용한다
     ```swift
    func makeCroppedVideo(crop: CGRect, asset: AVAsset) async throws -> AVMutableVideoComposition {
        let videoComposition = try await AVMutableVideoComposition.videoComposition(with: asset) { request in
            let cropFilter = CIFilter(name: "CICrop")!
            cropFilter.setValue(request.sourceImage, forKey: kCIInputImageKey)
            cropFilter.setValue(CIVector(cgRect: crop), forKey: "inputRectanlge")
            let cropped = cropFilter.outputImage!
            let translated = cropped.transformed(by: CGAffineTransform(translationX: -crop.origin.x, y: -crop.origin.y))
            request.finish(with: translated, context: nil)
        }
        
        videoComposition.renderSize = crop.size
        
        return videoComposition
    }
     ```

해야 할 일

VideoMutableCompotion을 AVAsset으로 바꾸기.