### PR TITLE
[Fix] NavigationBar, GalleryView 터치 영역 수정

### DIFF
--- a/HongAndJerry/HongAndJerry/Source/DesignSystem/CtaButton.swift
+++ b/HongAndJerry/HongAndJerry/Source/DesignSystem/CtaButton.swift
@@ -43,13 +43,14 @@ extension CtaButton: View {
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
             }
-            .padding(.horizontal)
             .frame(maxWidth: .infinity)
             .frame(height: 55)
             .background(isDisabled ? .inactive : Color.accent)
             .clipShape(RoundedRectangle(cornerRadius: 4))
         }
         .disabled(isDisabled)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 48)
     }
 }
 

--- a/HongAndJerry/HongAndJerry/Source/Extension/View++.swift
+++ b/HongAndJerry/HongAndJerry/Source/Extension/View++.swift
@@ -1,0 +1,14 @@
+//
+//  View++.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/28/25.
+//
+
+import SwiftUI
+
+extension View {
+    func hjNavigationBar(title: String) -> some View {
+            self.modifier(HJNavigationBar(title: title))
+        }
+}

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropView.swift
@@ -52,7 +52,6 @@ struct CropView: View {
             .tabViewStyle(.page(indexDisplayMode: .never))    // 탭뷰 좌우 스크롤 설정
             
             HStack {
-                
                 if viewModel.currentIndex > 0 {
                     previousButton
                 }
@@ -67,6 +66,8 @@ struct CropView: View {
                     nextButton
                 }
             }
+            .padding(.vertical, 16)
+            .padding(.horizontal, 16)
         }
     }
     
@@ -81,7 +82,7 @@ struct CropView: View {
                     .overlay(alignment: .topLeading) {
                         GeometryReader { geometry in
                             CropBox(rect: viewModel.bindingForCropRect(at: videoIndex))
-                                .allowsHitTesting(true) // 터치 이벤트 활성화
+                                .allowsHitTesting(true)
                                 .onAppear {
                                     self.imageViewSize = geometry.size
                                     if crop.cropRect == CGRect(x: 0, y: 0, width: 100, height: 100) {

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropView.swift
@@ -33,11 +33,11 @@ struct CropView: View {
                     router.push(screen: .videoEditView([]))
                 }
             }
-            .padding(.horizontal, 16)
             .onAppear {
                 viewModel.send(.loadThumbnail)
             }
         }
+        .hjNavigationBar(title: ExportNameSpace.AppMain.cropVideoTitle)
     }
     
     var tabView: some View {
@@ -67,7 +67,6 @@ struct CropView: View {
                     nextButton
                 }
             }
-            .padding(.horizontal, 16)
         }
     }
     

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Export/ExportNameSpace.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Export/ExportNameSpace.swift
@@ -37,5 +37,7 @@ extension ExportNameSpace {
     enum AppMain {
         static let AppName = "WVDO"
         static let frameNavigationTitle = "프레임 선택"
+        static let selectVideoTitle = "영상 선택"
+        static let cropVideoTitle = " 비율 조정"
     }
 }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Home/View/FrameSelectView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Home/View/FrameSelectView.swift
@@ -31,25 +31,14 @@ extension FrameSelectView: View {
             ) {
                 router.push(screen: .selectVideo)
             }
-            .padding()
         }
         .navigationDestination(for: Screen.self) { _ in
             GalleryView()
                 .environment(router)
         }
         .background(Color.background)
-        .navigationTitle(ExportNameSpace.AppMain.frameNavigationTitle)
         .foregroundStyle(.font)
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    router.pop()
-                } label: {
-                    Image(systemName: Icon.SFsymbol.chevronLeft)
-                }
-            }
-        }
+        .hjNavigationBar(title: ExportNameSpace.AppMain.frameNavigationTitle)
     }
 }
 

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Home/View/HomeView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Home/View/HomeView.swift
@@ -40,12 +40,11 @@ extension HomeView: View {
                     isDisabled: .constant(false)) {
                         router.push(screen: .selectFrame)
                     }
-                    .padding(.horizontal)
             }
             .background(Color.background)
             .navigationDestination(for: Screen.self) { screen in
                 RoutingView(navigateDestination: screen)
-                .environment(router)
+                    .environment(router)
             }
             .sheet(isPresented: $showPlayer) {
                 if let asset = selectedAsset {

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Picker/AllVideoGridScrollView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Picker/AllVideoGridScrollView.swift
@@ -12,23 +12,27 @@ struct AllVideoGridScrollView: View {
     var viewModel: GalleryViewModel
     
     var body: some View {
-        ScrollView {
-            LazyVGrid(
-                columns: Array(
-                    repeating: GridItem(.flexible(), spacing: 2),
-                    count: 3),
-                spacing: 2
-            ) {
-                ForEach(viewModel.videos, id: \.localIdentifier) { video in
-                    VideoThumbnail(
-                        video: video,
-                        isSelected: viewModel.selectedVideos.contains(video),
-                        selectionIndex: viewModel.getSelectionIndex(for: video),
-                        onTap: { viewModel.send(.toggleSelection(video)) }
-                    )
+        
+        VStack {
+            ScrollView {
+                LazyVGrid(
+                    columns: Array(
+                        repeating: GridItem(.flexible(), spacing: 2),
+                        count: 3),
+                    spacing: 2
+                ) {
+                    ForEach(viewModel.videos, id: \.localIdentifier) { video in
+                        VideoThumbnail(
+                            video: video,
+                            isSelected: viewModel.selectedVideos.contains(video),
+                            selectionIndex: viewModel.getSelectionIndex(for: video),
+                            onTap: { viewModel.send(.toggleSelection(video)) }
+                        )
+                    }
                 }
+                .padding(.bottom, 70)
+                .scrollIndicators(.hidden)
             }
-            .scrollIndicators(.hidden)
         }
         .onAppear {
             Task {

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Picker/GalleryView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Picker/GalleryView.swift
@@ -25,22 +25,27 @@ struct GalleryView: View {
                         .transition(.move(edge: .top).combined(with: .opacity))
                         .animation(.easeInOut, value: viewModel.selectedVideos)
                 }
-                AllVideoGridScrollView(viewModel: viewModel)
-                    .animation(.easeInOut, value: viewModel.selectedVideos)
-                Spacer()
-                VStack {
-                    if viewModel.canProceedToEdit {
-                        CtaButton(
-                            buttonType: .next,
-                            isDisabled: .constant(false)
-                        ) {
-                            router.push(screen: .editVideoRatio(viewModel.selectedVideos))
+                
+                ZStack {
+                    AllVideoGridScrollView(viewModel: viewModel)
+                        .animation(.easeInOut, value: viewModel.selectedVideos)
+                    
+                    VStack {
+                        Spacer()
+                        
+                        if viewModel.canProceedToEdit {
+                            CtaButton(
+                                buttonType: .next,
+                                isDisabled: .constant(false)
+                            ) {
+                                router.push(screen: .editVideoRatio(viewModel.selectedVideos))
+                            }
                         }
-                        .padding(.horizontal, 16)
                     }
                 }
             }
         }
+        .hjNavigationBar(title: ExportNameSpace.AppMain.selectVideoTitle)
     }
 }
 

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Picker/VideoThumbnail.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Picker/VideoThumbnail.swift
@@ -29,6 +29,7 @@ struct VideoThumbnail: View {
             }
         }
         .aspectRatio(1, contentMode: .fit)
+        .contentShape(Rectangle())
         .onTapGesture {
             onTap()
         }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorHeaderView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorHeaderView.swift
@@ -10,20 +10,20 @@ import SwiftUI
 /// 에디터 화면 상단에 표시될 헤더 뷰입니다.
 /// 뒤로가기 버튼과 내보내기 버튼을 포함합니다.
 struct EditorHeaderView: View {
+    @EnvironmentObject var router: Router
+    
     var body: some View {
         HStack {
-            // 뒤로가기 버튼
             Button {
-                // TODO: 뒤로가기 기능 구현
+                router.pop()
             } label: {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(.system(size: 22, weight: .medium))
                     .foregroundColor(.white)
             }
 
             Spacer()
-
-            // 내보내기 버튼
+            
             Button {
                 // TODO: 내보내기 기능 구현
             } label: {
@@ -32,7 +32,8 @@ struct EditorHeaderView: View {
                     .foregroundColor(.accent)
             }
         }
+        .padding(.leading, 8)
+        .padding(.trailing, 28)
         .padding(.vertical, 16)
-        .padding(.horizontal, 28)
     }
 }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorWorkspaceView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorWorkspaceView.swift
@@ -46,7 +46,10 @@ struct EditorWorkspaceView: View {
                     .font(.SUITTimer)
                     .foregroundColor(.white)
                     .frame(height: EditConstants.rulerHeight)
-                    .background(.black)
+                    .background(
+                        Rectangle().fill(.black)
+                    )
+                    .padding(.leading, 16)
             }
             .frame(height: UIScreen.main.bounds.height / 3)
         }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/VideoEditorView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/VideoEditorView.swift
@@ -32,6 +32,7 @@ struct VideoEditorView: View {
             }
         }
         .environment(viewModel)
+        .navigationBarHidden(true)
     }
 }
 

--- a/HongAndJerry/HongAndJerry/Source/Service/Navigation/HJNavigationBar.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/Navigation/HJNavigationBar.swift
@@ -1,0 +1,49 @@
+//
+//  HJNavigationBar.swift
+//  HongAndJerry
+//
+//  Created by Rama on 7/28/25.
+//
+
+import SwiftUI
+
+struct HJNavigationBar: ViewModifier {
+    let title: String
+    let backgroundColor: UIColor = .background
+    let backButtonColor: UIColor = .white
+    
+    init(title: String) { self.title = title }
+    
+    func body(content: Content) -> some View {
+        content
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.automatic)
+            .onAppear {
+                setNavigationBarAppearance()
+            }
+    }
+    
+    private func setNavigationBarAppearance() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = backgroundColor
+        
+        appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        
+        let backButtonAppearance = UIBarButtonItemAppearance()
+        backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.clear]
+        appearance.backButtonAppearance = backButtonAppearance
+        
+        let backIcon = UIImage(systemName: "chevron.left",
+                               withConfiguration: UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold))?
+            .withTintColor(
+                backButtonColor,
+                renderingMode: .alwaysOriginal
+            )
+        appearance.setBackIndicatorImage(backIcon, transitionMaskImage: backIcon)
+        
+        UINavigationBar.appearance().standardAppearance = appearance
+        UINavigationBar.appearance().compactAppearance = appearance
+        UINavigationBar.appearance().scrollEdgeAppearance = appearance
+    }
+}


### PR DESCRIPTION
## 🐱 **작업한 내용, 스크린샷**
| NaviBar 스크린샷 1 | NaviBar 스크린샷 2 | 비디오 편집 뷰은 커스텀 NaviBar |
|:---:|:---:|:---:|
| <img width="393" alt="image" src="https://github.com/user-attachments/assets/c1bf541a-4b2e-427f-82ea-689e87d03e63" /> | <img width="393" alt="image" src="https://github.com/user-attachments/assets/cff5ce87-ffe3-41c7-834a-9cfa2376c997" /> | <img width="393" alt="image" src="https://github.com/user-attachments/assets/055305a2-36f5-489c-b04a-4599e34d650f" /> |

- NavigationBar 전체 뷰에 적용
- GalleryView Grid에서 영상을 선택할 때 터치 영역에 오류 수정
  - GeometryReader가 차지하는 공간이 터치 영역보다 커서 생긴 이쓔~ `.contentShape(Rectangle())` 설정해줘서 해결했어요
## 🐭 **참고 사항**
### 네비게이션 바
- 네비게이션바를 수정했습니다. 커스텀으로 만들면 slide 액션을 따로 설정해야 하기 때문에 `NavigationBarAppearance`를 변경해서 BackButton, Title을 수정하는 방식을 선택했습니다.
- 사용한 방식이 BackButton의 레이아웃을 변경할 수 없어서 백버튼 위치가 어색할 수 있습니다. 논의 후에 필요하면 커스텀으로 ˗ˋˏ 교체하겠습니다 ˎˊ˗
- 비디오를 트리밍하는 뷰는 커스텀으로 `EditorHeaderView`를 만들어 네비게이션 바를 대체했습니다.

```
    private func setNavigationBarAppearance() {
        let appearance = UINavigationBarAppearance()
        appearance.configureWithTransparentBackground()
        appearance.backgroundColor = backgroundColor
        
        appearance.titleTextAttributes = [.foregroundColor: UIColor.white]

        // 네비바 좌측에 이전 뷰의 텍스트를 투명 처리하여 BackButton만 보일 수 있게
        let backButtonAppearance = UIBarButtonItemAppearance()        
        backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.clear]
        appearance.backButtonAppearance = backButtonAppearance
        
        // backButton 아이콘 설정, 적용
        let backIcon = UIImage(systemName: "chevron.left",
                               withConfiguration: UIImage.SymbolConfiguration(pointSize: 16, weight: .semibold))?
            .withTintColor(
                backButtonColor,
                renderingMode: .alwaysOriginal
            )
        appearance.setBackIndicatorImage(backIcon, transitionMaskImage: backIcon)
        
        UINavigationBar.appearance().standardAppearance = appearance
        UINavigationBar.appearance().compactAppearance = appearance
        UINavigationBar.appearance().scrollEdgeAppearance = appearance
    }
}

// View에 적용 예시
ZStack { ... }
.hjNavigationBar(title: ExportNameSpace.AppMain.cropVideoTitle)
```

resolved #34 