### PR TITLE
[Feat] ExportButton 기능 병합

### DIFF
--- a/HongAndJerry/HongAndJerry/Source/DesignSystem/CtaButton.swift
+++ b/HongAndJerry/HongAndJerry/Source/DesignSystem/CtaButton.swift
@@ -50,7 +50,7 @@ extension CtaButton: View {
         }
         .disabled(isDisabled)
         .padding(.horizontal, 16)
-        .padding(.bottom, 48)
+        .padding(.bottom, 36)
     }
 }
 

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Crop/CropView.swift
@@ -31,7 +31,7 @@ struct CropView: View {
                         tabView
                     }
                 }
-                CtaButton(buttonType: .next, isDisabled: .constant(false)) {
+                CtaButton(buttonType: .next, isDisabled: .constant(viewModel.currentIndex != 2)) {
                     Task {
                         await viewModel.cropVideos()
                         let segments = await viewModel.createVideoSegments()

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Export/Protocol/VideoSave.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Export/Protocol/VideoSave.swift
@@ -8,5 +8,5 @@
 import Photos
 
 protocol VideoSaving {
-    func save(video: AVAsset, to album: PHAssetCollection) async throws
+    func save(video asset: AVAsset, videoComposition: AVVideoComposition?, to album: PHAssetCollection) async throws
 }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Export/VideoSaver.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Export/VideoSaver.swift
@@ -7,19 +7,51 @@
 
 import Photos
 
+enum ExportError: Error {
+    case exportSessionCreationFailed
+    case exportFailed(Error?)
+    case exportCancelled
+    case unknown
+}
+
 final class VideoSaver: VideoSaving {
 
     func save(
-        video: AVAsset,
+        video asset: AVAsset,
+        videoComposition: AVVideoComposition?,
         to album: PHAssetCollection
     ) async throws {
-        guard
-            let url = (video as? AVURLAsset)?.url
-        else { return }
+        guard let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetHighestQuality) else {
+            throw ExportError.exportSessionCreationFailed
+        }
+        
+        let tempDirectory = FileManager.default.temporaryDirectory
+        let outputURL = tempDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("mov")
+        
+        exportSession.outputURL = outputURL
+        exportSession.outputFileType = .mov
+        exportSession.videoComposition = videoComposition
+        
+        await exportSession.export()
+        
+        switch exportSession.status {
+        case .completed:
+            try await saveVideoFile(at: outputURL, to: album)
+            try? FileManager.default.removeItem(at: outputURL)
+            
+        case .failed:
+            throw ExportError.exportFailed(exportSession.error)
+        case .cancelled:
+            throw ExportError.exportCancelled
+        default:
+            throw ExportError.unknown
+        }
+    }
 
+    private func saveVideoFile(at fileURL: URL, to album: PHAssetCollection) async throws {
         try await PHPhotoLibrary.shared().performChanges {
             guard
-                let assetRequest = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url),
+                let assetRequest = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: fileURL),
                 let placeholder = assetRequest.placeholderForCreatedAsset,
                 let albumChangeRequest = PHAssetCollectionChangeRequest(for: album)
             else { return }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Export/View/ExportButton.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Export/View/ExportButton.swift
@@ -12,13 +12,15 @@ struct ExportButton {
     @State private var viewModel = ExportViewModel()
     @State private var showAlert = false
     let video: AVAsset?
+    let composition: AVVideoComposition?
+    @EnvironmentObject var router: Router
 }
 
 extension ExportButton: View {
     var body: some View {
         Button {
             if let video = video {
-                viewModel.saveVideo(video)
+                viewModel.saveVideo(video, videoComposition: composition)
                 showAlert = true
             } else {
                 /// TODO: video 아직 로드 안되었을 때 로직 추가해야 함.
@@ -33,6 +35,9 @@ extension ExportButton: View {
                 title: Text(viewModel.alertModel.title),
                 message: Text(viewModel.alertModel.message),
                 dismissButton: .default(Text(viewModel.alertModel.buttonTitle)) {
+                    if viewModel.alertModel.buttonTitle == ExportNameSpace.AlertSuccessMessage.buttonTitle {
+                        router.popToRoot()
+                    }
                     goToSettings()
                 }
             )

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Export/View/ExportButton.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Export/View/ExportButton.swift
@@ -1,5 +1,5 @@
 //
-//  ViewExample.swift
+//  ExportButton.swift
 //  HongAndJerry
 //
 //  Created by Rama on 7/16/25.
@@ -8,17 +8,21 @@
 import Photos
 import SwiftUI
 
-struct ExportView {
+struct ExportButton {
     @State private var viewModel = ExportViewModel()
     @State private var showAlert = false
-    let video: AVAsset
+    let video: AVAsset?
 }
 
-extension ExportView: View {
+extension ExportButton: View {
     var body: some View {
         Button {
-            viewModel.saveVideo(video)
-            showAlert = true
+            if let video = video {
+                viewModel.saveVideo(video)
+                showAlert = true
+            } else {
+                /// TODO: video 아직 로드 안되었을 때 로직 추가해야 함.
+            }
         } label: {
             Text(ExportNameSpace.ExportView.export)
                 .font(.SUITHeader)
@@ -36,7 +40,7 @@ extension ExportView: View {
     }
 }
 
-private extension ExportView {
+private extension ExportButton {
     func goToSettings() {
         if viewModel.alertModel.buttonTitle == ExportNameSpace.AlertRejectMessage.buttonTitle {
             if let url = URL(string: UIApplication.openSettingsURLString) {

--- a/HongAndJerry/HongAndJerry/Source/Presentation/Export/ViewModel/ExportViewModel.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/Export/ViewModel/ExportViewModel.swift
@@ -15,9 +15,9 @@ final class ExportViewModel {
     private let videoSaver: VideoSaver
     
     var alertModel: ExportAlertModel = .init(
-        title: "",
-        message: "",
-        buttonTitle: ""
+        title: ExportNameSpace.AlertSuccessMessage.title,
+        message: ExportNameSpace.AlertSuccessMessage.message,
+        buttonTitle: ExportNameSpace.AlertSuccessMessage.buttonTitle
     )
     
     init(
@@ -28,7 +28,7 @@ final class ExportViewModel {
         self.videoSaver = videoSaver
     }
     
-    func saveVideo(_ video: AVAsset) {
+    func saveVideo(_ video: AVAsset, videoComposition: AVVideoComposition?) {
         MediaPermissionUtils.requestPermission { [weak self] permission in
             guard let self else { return }
             
@@ -40,15 +40,15 @@ final class ExportViewModel {
                 )
                 return
             }
-            self.saveToAlbum(video)
+            self.saveToAlbum(video, videoComposition: videoComposition)
         }
     }
     
-    private func saveToAlbum(_ video: AVAsset) {
+    private func saveToAlbum(_ video: AVAsset, videoComposition: AVVideoComposition?) {
         Task {
             do {
                 let album = try albumRepository.checkAlbum(named: albumTitle)
-                try await videoSaver.save(video: video, to: album)
+                try await videoSaver.save(video: video, videoComposition: videoComposition, to: album)
                 alertModel = ExportAlertModel(
                     title: ExportNameSpace.AlertSuccessMessage
                         .title,

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorHeaderView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorHeaderView.swift
@@ -6,11 +6,14 @@
 //
 
 import SwiftUI
+import AVFoundation
 
 /// 에디터 화면 상단에 표시될 헤더 뷰입니다.
 /// 뒤로가기 버튼과 내보내기 버튼을 포함합니다.
 struct EditorHeaderView: View {
     @EnvironmentObject var router: Router
+    
+    var videoAsset: AVAsset?
     
     var body: some View {
         HStack {
@@ -24,13 +27,7 @@ struct EditorHeaderView: View {
 
             Spacer()
             
-            Button {
-                // TODO: 내보내기 기능 구현
-            } label: {
-                Text("내보내기")
-                    .font(.SUITHeader)
-                    .foregroundColor(.accent)
-            }
+            ExportButton(video: videoAsset)
         }
         .padding(.leading, 8)
         .padding(.trailing, 28)

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorHeaderView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorHeaderView.swift
@@ -14,6 +14,7 @@ struct EditorHeaderView: View {
     @EnvironmentObject var router: Router
     
     var videoAsset: AVAsset?
+    var videoComposition: AVVideoComposition?
     
     var body: some View {
         HStack {
@@ -27,7 +28,7 @@ struct EditorHeaderView: View {
 
             Spacer()
             
-            ExportButton(video: videoAsset)
+            ExportButton(video: videoAsset, composition: videoComposition)
         }
         .padding(.leading, 8)
         .padding(.trailing, 28)

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorTimelineView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorTimelineView.swift
@@ -72,28 +72,12 @@ struct EditorTimelineView: View {
         .gesture(
             DragGesture()
                 .onChanged { value in
-                    // 진행 중인 관성 애니메이션 중단
-                    if isAnimatingScroll {
-                        isAnimatingScroll = false
-                        self.currentOffset = self.currentOffset
-                    }
-                    
                     // 드래그 시작 처리
                     if !isTimelineDragging {
+                        viewModel.playerController.pause()
                         isTimelineDragging = true
                         startDragOffset = currentOffset
-                        lastDragEvent = (time: value.time, translation: value.translation)
                     }
-                    
-                    // 속도 계산
-                    if let last = lastDragEvent {
-                        let timeInterval = value.time.timeIntervalSince(last.time)
-                        if timeInterval > 0 {
-                            let distance = value.translation.width - last.translation.width
-                            self.gestureVelocity = distance / timeInterval // 단위: points/sec
-                        }
-                    }
-                    self.lastDragEvent = (time: value.time, translation: value.translation)
                     
                     // 오프셋 업데이트
                     let newOffset = startDragOffset + value.translation.width
@@ -102,36 +86,9 @@ struct EditorTimelineView: View {
                 .onEnded { value in
                     isTimelineDragging = false
                     
-                    // 손가락을 떼기 전 잠시 멈췄는지 확인
-                    let timeSinceLastDrag = value.time.timeIntervalSince(lastDragEvent?.time ?? value.time)
-                    if timeSinceLastDrag > 0.05 { // 50ms 이상 움직임이 없으면 속도 0으로 처리
-                        self.gestureVelocity = 0
-                    }
-                    self.lastDragEvent = nil // 상태 초기화
-                    
-                    // 계산된 속도를 기반으로 관성 적용
-                    let projectedOffset = self.currentOffset + self.gestureVelocity * 0.4 // 관성 강도 조절
-                    let clampedProjectedOffset = clampOffset(projectedOffset)
-                    
-                    // 속도에 기반해 애니메이션 시간 동적 조절
-                    // 최소 0.5초, 최대 7초로 변경하여 관성 효과를 더 길게 유지
-                    let animationDuration = min(max(abs(self.gestureVelocity) / 1000, 0.5), 7.0)
-                    
-                    // 관성 스크롤 애니메이션 시작
-                    isAnimatingScroll = true
-                    withAnimation(.easeOut(duration: animationDuration)) {
-                        self.currentOffset = clampedProjectedOffset
-                    }
+                    let clampedProjectedOffset = clampOffset(self.currentOffset)
                     
                     seekToOffset(clampedProjectedOffset)
-                    
-                    // 애니메이션이 끝나는 시점에 상태를 재설정합니다.
-                    DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration) {
-                        // 애니메이션이 끝난 후에도 사용자가 드래그를 시작하지 않았을 경우에만 상태를 변경합니다.
-                        if !isTimelineDragging {
-                            isAnimatingScroll = false
-                        }
-                    }
                 }
         )
         .clipped()

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorWorkspaceView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorWorkspaceView.swift
@@ -15,14 +15,17 @@ struct EditorWorkspaceView: View {
     
     /// 뷰 전환 애니메이션을 위한 네임스페이스입니다.
     let namespace: Namespace.ID
-
+    
     var body: some View {
         VStack(spacing: 0) {
-            EditorHeaderView(videoAsset: viewModel.getFinalVideoAsset())
+            EditorHeaderView(
+                videoAsset: viewModel.getFinalVideoAsset(),
+                videoComposition: viewModel.getFinalVideoComposition()
+            )
             
             VideoPlayerView(playerController: viewModel.playerController)
-                // 이 뷰가 "videoPlayer"라는 ID를 가짐을 선언하여
-                // FullScreenPlayerView의 플레이어와 연결합니다.
+            // 이 뷰가 "videoPlayer"라는 ID를 가짐을 선언하여
+            // FullScreenPlayerView의 플레이어와 연결합니다.
                 .matchedGeometryEffect(id: "videoPlayer", in: namespace)
                 .padding(.top, 21)
                 .padding(.bottom, 8)

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorWorkspaceView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorWorkspaceView.swift
@@ -18,7 +18,7 @@ struct EditorWorkspaceView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            EditorHeaderView()
+            EditorHeaderView(videoAsset: viewModel.getFinalVideoAsset())
             
             VideoPlayerView(playerController: viewModel.playerController)
                 // 이 뷰가 "videoPlayer"라는 ID를 가짐을 선언하여

--- a/HongAndJerry/HongAndJerry/Source/ViewModel/VideoViewModel.swift
+++ b/HongAndJerry/HongAndJerry/Source/ViewModel/VideoViewModel.swift
@@ -197,4 +197,12 @@ final class VideoViewModel {
             return nil
         }
     }
+    
+    func getFinalVideoComposition() -> AVVideoComposition? {
+        if let playerItem = self.playerItem {
+            return playerItem.videoComposition
+        } else {
+            return nil
+        }
+    }
 }

--- a/HongAndJerry/HongAndJerry/Source/ViewModel/VideoViewModel.swift
+++ b/HongAndJerry/HongAndJerry/Source/ViewModel/VideoViewModel.swift
@@ -12,6 +12,8 @@ import Observation
 @Observable
 final class VideoViewModel {
     var segments: [VideoSegment] = []
+    private var playerItem: AVPlayerItem?
+    
     var draggingHandleType: HandleType = .none
     var handleDragTranslation: CGFloat = .zero
     var selectedSegmentID: UUID?
@@ -58,6 +60,8 @@ final class VideoViewModel {
             }
             
             let buildResult = try await compositionBuilder.build(from: segments)
+            self.playerItem = buildResult.playerItem
+            
             playerController.replaceCurrentItem(with: buildResult.playerItem)
         } catch {
             print("Error rebuilding player item: \(error)")
@@ -183,6 +187,14 @@ final class VideoViewModel {
         } catch {
             // operation 적용 중 에러가 발생하면 로그를 출력합니다.
             print("Failed to perform edit operation: \(error)")
+        }
+    }
+    
+    func getFinalVideoAsset() -> AVAsset? {
+        if let playerItem = self.playerItem {
+            return playerItem.asset
+        } else {
+            return nil
         }
     }
 }


### PR DESCRIPTION
## 🐱 **작업한 내용, 스크린샷**
Export Button 기능 병합

## 🐭 **참고 사항**
1. VideoViewModel에 AVAsset을 반환하는 함수를 추가했습니다.
```swift
    func getFinalVideoAsset() -> AVAsset? {
        if let playerItem = self.playerItem {
            return playerItem.asset
        } else {
            return nil
        }
    }
```

2. ExportButton에 필요한 AVAsset을 ViewModel에서 제공받아 두 컴포넌트를 연동합니다.
```swift
struct EditorHeaderView: View {
    @EnvironmentObject var router: Router
    
    var videoAsset: AVAsset?
    
    var body: some View {
        HStack {
            Button {
                router.pop()
            } label: {
                Image(systemName: "chevron.left")
                    .font(.system(size: 22, weight: .medium))
                    .foregroundColor(.white)
            }

            Spacer()
            
            ExportButton(video: videoAsset)
        }
        .padding(.leading, 8)
        .padding(.trailing, 28)
        .padding(.vertical, 16)
    }
}
```
