### PR TITLE
[Feat] video track별로 영상이 종료될 시 검은 화면이 나오도록 수정

### DIFF
--- a/HongAndJerry/HongAndJerry/Source/Service/CompositionBuilder.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/CompositionBuilder.swift
@@ -8,6 +8,29 @@
 import Foundation
 import AVFoundation
 
+enum CompositionBuildError: Error {
+    case failedToCreateVerticalVideoComposition
+    case failedToAddTrack
+    case noValidTracks
+}
+
+enum TrackTypes {
+    struct VideoTrackInfo {
+        let trackID: CMPersistentTrackID
+        let duration: CMTime
+    }
+    
+    struct AudioTrackInfo {
+        let trackID: CMPersistentTrackID
+    }
+}
+
+typealias AddTracksResult = (
+    video: [TrackTypes.VideoTrackInfo],
+    audio: [TrackTypes.AudioTrackInfo]
+)
+
+
 @MainActor
 struct CompositionBuilder {
     
@@ -24,11 +47,11 @@ struct CompositionBuilder {
         let composition = AVMutableComposition()
         var totalDuration: CMTime = .zero
         
-        let trackIDs = try await addTracks(to: composition, from: segments, totalDuration: &totalDuration)
+        let (video, _) = try await addTracks(to: composition, from: segments, totalDuration: &totalDuration)
         
-        let videoComposition = createVerticalVideoComposition(
+        let videoComposition = try await createVerticalVideoComposition(
             composition: composition,
-            trackIDs: trackIDs.video,
+            trackInfos: video,
             totalDuration: totalDuration
         )
         
@@ -45,22 +68,30 @@ struct CompositionBuilder {
         to composition: AVMutableComposition,
         from segments: [VideoSegment],
         totalDuration: inout CMTime
-    ) async throws -> (video: [CMPersistentTrackID], audio: [CMPersistentTrackID]) {
-        var videoTrackIDs: [CMPersistentTrackID] = []
-        var audioTrackIDs: [CMPersistentTrackID] = []
+    ) async throws -> AddTracksResult {
+        var videoTrackInfos: [TrackTypes.VideoTrackInfo] = []
+        var audioTrackInfos: [TrackTypes.AudioTrackInfo] = []
 
         for segment in segments {
             let asset = segment.source.asset
             
-            let timeRange = CMTimeRange(start: segment.startTime, duration: segment.trimmedDuration)
-
+            let timeRange = CMTimeRange(
+                start: segment.startTime,
+                duration: segment.trimmedDuration
+            )
+            
             if let videoTrack = try await asset.loadTracks(withMediaType: .video).first {
                 if let compositionTrack = composition.addMutableTrack(
                     withMediaType: .video,
                     preferredTrackID: kCMPersistentTrackID_Invalid
                 ) {
                     try compositionTrack.insertTimeRange(timeRange, of: videoTrack, at: .zero)
-                    videoTrackIDs.append(compositionTrack.trackID)
+                    videoTrackInfos.append(
+                        TrackTypes.VideoTrackInfo(
+                            trackID: compositionTrack.trackID,
+                            duration: timeRange.duration
+                        )
+                    )
                 }
             }
 
@@ -72,7 +103,11 @@ struct CompositionBuilder {
                         preferredTrackID: kCMPersistentTrackID_Invalid
                     ) {
                         try compositionTrack.insertTimeRange(timeRange, of: audioTrack, at: .zero)
-                        audioTrackIDs.append(compositionTrack.trackID)
+                        audioTrackInfos.append(
+                            TrackTypes.AudioTrackInfo(
+                                trackID: compositionTrack.trackID,
+                            )
+                        )
                     }
                 }
             }
@@ -80,15 +115,20 @@ struct CompositionBuilder {
             // 가장 긴 길이를 totalDuration으로 설정
             totalDuration = max(totalDuration, timeRange.duration)
         }
-        return (videoTrackIDs, audioTrackIDs)
+        
+        guard !videoTrackInfos.isEmpty else {
+            throw CompositionBuildError.noValidTracks
+        }
+        
+        return (video: videoTrackInfos, audio: audioTrackInfos)
     }
     
     /// 트랙을 수직으로 배열하기 위한 비디오 컴포지션을 생성합니다.
     private func createVerticalVideoComposition(
         composition: AVMutableComposition,
-        trackIDs: [CMPersistentTrackID],
+        trackInfos: [TrackTypes.VideoTrackInfo],
         totalDuration: CMTime
-    ) -> AVMutableVideoComposition {
+    ) async throws -> AVMutableVideoComposition {
         let renderSize = CGSize(width: 1080, height: 1821)
         let videoComposition = AVMutableVideoComposition()
         videoComposition.renderSize = renderSize
@@ -98,9 +138,13 @@ struct CompositionBuilder {
         mainInstruction.timeRange = CMTimeRange(start: .zero, duration: totalDuration)
         
         var layerInstructions: [AVMutableVideoCompositionLayerInstruction] = []
-        let videoHeight = renderSize.height / CGFloat(trackIDs.count)
+        let videoHeight = renderSize.height / CGFloat(trackInfos.count)
         
-        for (index, trackID) in trackIDs.enumerated() {
+        for (index, trackInfo) in trackInfos.enumerated() {
+            
+            let trackID = trackInfo.trackID
+            let duration = trackInfo.duration
+            
             guard let track = composition.track(withTrackID: trackID) else { continue }
             
             let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: track)
@@ -123,6 +167,8 @@ struct CompositionBuilder {
             // 4. 변환 결합
             let finalTransform = scaleTransform.concatenating(moveTransform)
             // --- 변환 계산 종료 ---
+
+            layerInstruction.setOpacity(0.0, at: duration)
             
             layerInstruction.setTransform(finalTransform, at: .zero)
             layerInstructions.append(layerInstruction)


### PR DESCRIPTION
## 🐱 **작업한 내용, 스크린샷**
video track별로 영상이 종료될 시 검은 화면이 나오도록 기능 수정

### CompositionBuilder 코드 수정

각 트랙별로 영상이 끝날 때 해당 layer의 opacity 값을 0으로 줌으로써 영상을 검은 화면으로 만듭니다.
```swift
layerInstruction.setOpacity(0.0, at: duration)
```

전체코드
```swift
    /// 트랙을 수직으로 배열하기 위한 비디오 컴포지션을 생성합니다.
    private func createVerticalVideoComposition(
        composition: AVMutableComposition,
        trackInfos: [TrackTypes.VideoTrackInfo],
        totalDuration: CMTime
    ) async throws -> AVMutableVideoComposition {
        let renderSize = CGSize(width: 1080, height: 1821)
        let videoComposition = AVMutableVideoComposition()
        videoComposition.renderSize = renderSize
        videoComposition.frameDuration = CMTime(value: 1, timescale: 60)
        
        let mainInstruction = AVMutableVideoCompositionInstruction()
        mainInstruction.timeRange = CMTimeRange(start: .zero, duration: totalDuration)
        
        var layerInstructions: [AVMutableVideoCompositionLayerInstruction] = []
        let videoHeight = renderSize.height / CGFloat(trackInfos.count)
        
        for (index, trackInfo) in trackInfos.enumerated() {
            
            let trackID = trackInfo.trackID
            let duration = trackInfo.duration
            
            guard let track = composition.track(withTrackID: trackID) else { continue }
            
            let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: track)
            let assetSize = track.naturalSize
            
            // --- 변환 계산 ---
            // 1. 너비에 맞게 스케일 조정
            let scaleFactor = renderSize.width / assetSize.width
            let scaleTransform = CGAffineTransform(scaleX: scaleFactor, y: scaleFactor)
            
            // 2. 할당된 슬롯 내에서 비디오를 수직으로 중앙 정렬
            let scaledAssetHeight = assetSize.height * scaleFactor
            let yOffset = (videoHeight - scaledAssetHeight) / 2
            
            // 3. 위에서부터 슬롯 위치 지정
            let yPosition = ((CGFloat(index + 1) * videoHeight) + yOffset) - (renderSize.height / 3)
            
            let moveTransform = CGAffineTransform(translationX: 0, y: yPosition)
            
            // 4. 변환 결합
            let finalTransform = scaleTransform.concatenating(moveTransform)
            // --- 변환 계산 종료 ---

            layerInstruction.setOpacity(0.0, at: duration)
            
            layerInstruction.setTransform(finalTransform, at: .zero)
            layerInstructions.append(layerInstruction)
        }
        
        mainInstruction.layerInstructions = layerInstructions.reversed()
        videoComposition.instructions = [mainInstruction]
        
        return videoComposition
    }
```

### 결과
https://github.com/user-attachments/assets/15561d5c-15e2-47b9-ad60-18fc1c3d9841


