### PR TITLE
Feat/#49/resize trackruler interval and haptic

### DIFF
--- a/HongAndJerry/GEMINI.md
+++ b/HongAndJerry/GEMINI.md
@@ -142,7 +142,12 @@ HongAndJerry/
 - **Persona**: The Film Editor.
 - **Primary Responsibility**: To translate the `[VideoSegment]` array into a playable `AVPlayerItem` by handling all complex `AVFoundation` logic.
 - **Implementation Rationale**: MUST be a `struct` (value type) because it is a stateless worker. It takes input, produces output, and retains no memory of past operations, ensuring thread safety and predictability.
-- **Core Behaviors & API**: `build(from: [VideoSegment]) -> CompositionBuildResult`.
+- **Core Behaviors & API**:
+    - **`build(from: [VideoSegment]) -> CompositionBuildResult`**: The public entry point. It orchestrates the entire build process by calling internal helper methods.
+    - **`addTracks(...)` (private helper)**: Extracts video and audio tracks from each `VideoSegment`, adds them to the main `AVMutableComposition`, and returns a crucial `AddTracksResult` tuple. This tuple contains arrays of `VideoTrackInfo` and `AudioTrackInfo`. The `VideoTrackInfo` struct is vital as it bundles a track's `trackID` with its precise `duration`.
+    - **`createVerticalVideoComposition(...)` (private helper)**: Performs two critical functions based on the `VideoTrackInfo` array:
+        1.  **Layout & Transformation**: Calculates the correct `CGAffineTransform` for each video track to position it in the 1x3 vertical stack.
+        2.  **Fade-to-Black Effect**: For each track, it applies a `setOpacity(0.0, at: trackInfo.duration)` instruction. This core logic makes the video track transparent the moment its content ends, preventing the last frame from freezing on screen and instead revealing the black background.
 
 #### c. `PlayerController` (class)
 - **Persona**: The Playback Operator.
@@ -161,7 +166,7 @@ HongAndJerry/
 - **Persona**: The Executive Producer.
 - **Primary Responsibility**: To act as the central coordinator, orchestrating all interactions between the UI and the system's specialist components. It owns the application's high-level state.
 - **Implementation Rationale**: MUST be a `class` as it owns the application's core state (`segments`) and must persist throughout the app's lifecycle.
-- **Core State & Data**: `segments` (Source of Truth), `playerController` (dependency), `isScrubbing`.
+- **Core State & Data**: `segments` (Source of Truth), `playerController` (dependency).
 - **Core Behaviors & API**:
     - `perform(operation: EditOperation)`: The single, unified entry point for all state-mutating requests from the UI.
     - `rebuildPlayerItem()`: A private method to coordinate the `CompositionBuilder` and `PlayerController` after a state change.

--- a/HongAndJerry/HongAndJerry/Source/Extension/VideoSegment++.swift
+++ b/HongAndJerry/HongAndJerry/Source/Extension/VideoSegment++.swift
@@ -19,7 +19,6 @@ extension VideoSegment: Hashable {
     }
 }
 
-#if DEBUG
 extension VideoSegment {
     /// 실제 비디오 파일을 기반으로 VideoSegment의 단일 목(mock) 객체를 비동기적으로 생성합니다.
     static func mock(
@@ -54,4 +53,3 @@ extension VideoSegment {
         return segments
     }
 }
-#endif

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorRulerView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorRulerView.swift
@@ -14,15 +14,18 @@ struct EditorRulerView: View {
     
     var body: some View {
         HStack(alignment: .bottom, spacing: 0) {
-            // totalDuration이 0보다 클 때만 눈금을 그립니다.
             if viewModel.playerController.totalDuration.seconds > 0 {
-                let totalSeconds = Int(viewModel.playerController.totalDuration.seconds.rounded(.up))
+                let totalSeconds = Int(
+                    viewModel
+                        .playerController
+                        .totalDuration
+                        .seconds
+                        .rounded(.up)
+                )
                 
-                // 1초 단위로 순회하며 2초, 10초 간격에 맞춰 그립니다.
                 ForEach(0..<totalSeconds, id: \.self) { second in
                     VStack {
-                        // 10초 간격의 레이블
-                        if second % 10 == 0
+                        if second % 5 == 0
                             || second == totalSeconds
                         {
                             Text("\(second)s")

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorTimelineView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorTimelineView.swift
@@ -8,7 +8,6 @@ struct EditorTimelineView: View {
     
     // 제스처 상태 관리
     @State private var isTimelineDragging = false
-    @State private var isAnimatingScroll = false
     @State private var startDragOffset: CGFloat = 0
     @State private var currentOffset: CGFloat = 0
     
@@ -60,10 +59,8 @@ struct EditorTimelineView: View {
             .offset(x: currentOffset)
             .onChange(of: viewModel.playerController.currentTime) {
                 // 사용자가 드래그하고 있지 않을 때만, 재생 시간에 맞춰 타임라인을 자동으로 스크롤합니다.
-                if !isTimelineDragging {
-                    let clampedOffset = clampOffset(self.currentOffset)
-                    self.currentOffset = clampedOffset
-                }
+                if !isTimelineDragging && viewModel.playerController.isPlaying {
+                    self.currentOffset = -(viewModel.playerController.currentTime.seconds * EditConstants.pixelsPerSecond)                }
             }
             .onAppear() {
                 viewModel.updateScreenWidth(geometry.size.width)

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorTimelineView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorTimelineView.swift
@@ -10,6 +10,8 @@ struct EditorTimelineView: View {
     @State private var isTimelineDragging = false
     @State private var startDragOffset: CGFloat = 0
     @State private var currentOffset: CGFloat = 0
+    @State private var dragDirection: DragDirection = .none
+    @State private var lastDragTranslation: CGFloat = 0
     
     // 햅틱 피드백 생성기 및 상태 변수 추가
     @State private var feedbackGenerator = UIImpactFeedbackGenerator(style: .light)
@@ -79,19 +81,36 @@ struct EditorTimelineView: View {
                         viewModel.playerController.pause()
                         isTimelineDragging = true
                         startDragOffset = currentOffset
+                        lastDragTranslation = 0 // 새 드래그 시작 시 초기화
                     }
                     
+                    // 방향 감지 (사용자 제안 방식)
+                    let currentTranslation = value.translation.width
+                    let delta = currentTranslation - lastDragTranslation
+                    
+                    if delta > 0 {
+                        self.dragDirection = .backward
+                    } else if delta < 0 {
+                        self.dragDirection = .forward
+                    } else {
+                        self.dragDirection = .none
+                    }
+                    
+                    // 다음 이벤트를 위해 현재 위치 저장
+                    self.lastDragTranslation = currentTranslation
+                    
                     // 오프셋 업데이트
-                    let newOffset = startDragOffset + value.translation.width
-                    updateOffset(newOffset, isDragging: true)
+                    let newOffset = startDragOffset + currentTranslation
+                    updateOffset(newOffset, isDragging: true, direction: self.dragDirection)
                 }
                 .onEnded { value in
                     isTimelineDragging = false
                     lastHapticSecond = -1
+                    lastDragTranslation = 0 // 드래그 종료 시 초기화
                     
                     let clampedProjectedOffset = clampOffset(self.currentOffset)
                     
-                    seekToOffset(clampedProjectedOffset)
+                    seekToOffset(clampedProjectedOffset, direction: .none)
                 }
         )
         .clipped()
@@ -108,17 +127,17 @@ struct EditorTimelineView: View {
     }
     
     /// 오프셋을 업데이트하고, 필요한 경우 플레이어 시간을 업데이트하는 함수
-    private func updateOffset(_ newOffset: CGFloat, isDragging: Bool) {
+    private func updateOffset(_ newOffset: CGFloat, isDragging: Bool, direction: DragDirection) {
         let clampedOffset = clampOffset(newOffset)
         self.currentOffset = clampedOffset
         
         if isDragging {
-            seekToOffset(clampedOffset)
+            seekToOffset(clampedOffset, direction: direction)
         }
     }
     
     /// 주어진 오프셋에 해당하는 시간으로 플레이어를 이동시키는 함수
-    private func seekToOffset(_ offset: CGFloat) {
+    private func seekToOffset(_ offset: CGFloat, direction: DragDirection) {
         let newTimeInSeconds = -offset / EditConstants.pixelsPerSecond
         let clampedTime = max(0, newTimeInSeconds)
         
@@ -128,6 +147,6 @@ struct EditorTimelineView: View {
             lastHapticSecond = currentSecond
         }
         
-        viewModel.playerController.seek(to: CMTime(seconds: clampedTime, preferredTimescale: 600))
+        viewModel.playerController.seek(to: CMTime(seconds: clampedTime, preferredTimescale: 600), direction: direction)
     }
 }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorTimelineView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorTimelineView.swift
@@ -11,6 +11,10 @@ struct EditorTimelineView: View {
     @State private var startDragOffset: CGFloat = 0
     @State private var currentOffset: CGFloat = 0
     
+    // 햅틱 피드백 생성기 및 상태 변수 추가
+    @State private var feedbackGenerator = UIImpactFeedbackGenerator(style: .light)
+    @State private var lastHapticSecond: Int = -1
+    
     // 수동 속도 계산을 위한 상태
     @State private var gestureVelocity: CGFloat = 0
     @State private var lastDragEvent: (time: Date, translation: CGSize)? = nil
@@ -83,6 +87,7 @@ struct EditorTimelineView: View {
                 }
                 .onEnded { value in
                     isTimelineDragging = false
+                    lastHapticSecond = -1
                     
                     let clampedProjectedOffset = clampOffset(self.currentOffset)
                     
@@ -116,6 +121,13 @@ struct EditorTimelineView: View {
     private func seekToOffset(_ offset: CGFloat) {
         let newTimeInSeconds = -offset / EditConstants.pixelsPerSecond
         let clampedTime = max(0, newTimeInSeconds)
+        
+        let currentSecond = Int(clampedTime)
+        if currentSecond != lastHapticSecond {
+            feedbackGenerator.impactOccurred()
+            lastHapticSecond = currentSecond
+        }
+        
         viewModel.playerController.seek(to: CMTime(seconds: clampedTime, preferredTimescale: 600))
     }
 }

--- a/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorWorkspaceView.swift
+++ b/HongAndJerry/HongAndJerry/Source/Presentation/VideoEditor/Editor/EditorWorkspaceView.swift
@@ -24,8 +24,6 @@ struct EditorWorkspaceView: View {
             )
             
             VideoPlayerView(playerController: viewModel.playerController)
-            // 이 뷰가 "videoPlayer"라는 ID를 가짐을 선언하여
-            // FullScreenPlayerView의 플레이어와 연결합니다.
                 .matchedGeometryEffect(id: "videoPlayer", in: namespace)
                 .padding(.top, 21)
                 .padding(.bottom, 8)
@@ -37,6 +35,7 @@ struct EditorWorkspaceView: View {
             ZStack(alignment: .topLeading) {
                 EditorTimelineView()
                 
+                // 중앙 헤드
                 // TODO: 분리
                 Rectangle()
                     .fill(.white)
@@ -44,6 +43,7 @@ struct EditorWorkspaceView: View {
                     .padding(.vertical, EditConstants.rulerHeight) // 상하 여백
                     .frame(maxWidth: .infinity) // ZStack 중앙 정렬을 위해
                 
+                // 왼쪽 상단에 있는 타이머
                 // TODO: 분리
                 Text("\(viewModel.playerController.currentTime.formattedString) / \(viewModel.playerController.totalDuration.formattedString)")
                     .font(.SUITTimer)

--- a/HongAndJerry/HongAndJerry/Source/Service/CompositionBuilder.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/CompositionBuilder.swift
@@ -47,7 +47,13 @@ struct CompositionBuilder {
         let composition = AVMutableComposition()
         var totalDuration: CMTime = .zero
         
-        let (video, _) = try await addTracks(to: composition, from: segments, totalDuration: &totalDuration)
+        let (
+            video, _
+        ) = try await addTracks(
+            to: composition,
+            from: segments,
+            totalDuration: &totalDuration
+        )
         
         let videoComposition = try await createVerticalVideoComposition(
             composition: composition,

--- a/HongAndJerry/HongAndJerry/Source/Service/PlayerController.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/PlayerController.swift
@@ -41,6 +41,7 @@ class PlayerController {
         removeTimeObserver()
         player.replaceCurrentItem(with: item)
         
+        let prevCurrentTime = currentTime
         guard let item = item else {
             totalDuration = .zero
             currentTime = .zero
@@ -49,6 +50,9 @@ class PlayerController {
         
         totalDuration = item.duration
         addTimeObserver()
+        
+        currentTime = min(prevCurrentTime, totalDuration)
+        seek(to: currentTime)
     }
     
     /// 재생을 시작합니다.

--- a/HongAndJerry/HongAndJerry/Source/Service/PlayerController.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/PlayerController.swift
@@ -69,9 +69,24 @@ class PlayerController {
     
     /// 지정된 시간으로 플레이헤드를 이동시킵니다.
     ///
-    /// - Parameter time: 이동할 대상 시간.
-    func seek(to time: CMTime) {
-        player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+    /// - Parameters:
+    ///   - time: 이동할 대상 시간.
+    ///   - isDragging: 사용자가 타임라인을 드래그하는 중인지 여부.
+    ///                 `true`일 경우, 성능 최적화를 위해 탐색 허용 오차를 사용합니다.
+    func seek(to time: CMTime, direction: DragDirection = .none) {
+        // 역방향 드래그일 때만 tolerance를 적용하고, 그 외에는 정확한 위치로 이동
+        let tolerance = (
+            direction == .backward
+        ) ? CMTime(
+            seconds: 0.5,
+            preferredTimescale: 600
+        ) : .zero
+        
+        player.seek(
+            to: time,
+            toleranceBefore: tolerance,
+            toleranceAfter: tolerance
+        )
     }
     
     // MARK: - Private Methods

--- a/HongAndJerry/HongAndJerry/Source/Service/PlayerController.swift
+++ b/HongAndJerry/HongAndJerry/Source/Service/PlayerController.swift
@@ -57,13 +57,13 @@ class PlayerController {
     
     /// 재생을 시작합니다.
     func play() {
-        player.play()
+        player.rate = 1
         isPlaying = true
     }
     
     /// 재생을 일시정지합니다.
     func pause() {
-        player.pause()
+        player.rate = 0
         isPlaying = false
     }
     

--- a/HongAndJerry/HongAndJerry/Source/Type/DragDirection.swift
+++ b/HongAndJerry/HongAndJerry/Source/Type/DragDirection.swift
@@ -1,12 +1,11 @@
-//
-//  DragDirection.swift
-//  HongAndJerry
-//
-//  Created by Rama on 7/20/25.
-//
+import Foundation
 
+/// 타임라인 드래그 방향을 나타내는 열거형입니다.
 enum DragDirection {
-    case left
-    case right
+    /// 순방향 (미래로) 탐색을 나타냅니다.
+    case forward
+    /// 역방향 (과거로) 탐색을 나타냅니다.
+    case backward
+    /// 드래그 중이 아니거나 방향이 없는 상태를 나타냅니다.
     case none
 }

--- a/HongAndJerry/HongAndJerry/Source/ViewModel/VideoViewModel.swift
+++ b/HongAndJerry/HongAndJerry/Source/ViewModel/VideoViewModel.swift
@@ -19,7 +19,9 @@ final class VideoViewModel {
     var selectedSegmentID: UUID?
     var scrollOffset: CGFloat = 0
     var screenWidth: CGFloat = 0
+    
     var isFullScreen: Bool = false
+    
     var segmentHandleOffsets: [UUID: (left: CGFloat, right: CGFloat)] = [:]
     
     private var initialLeftHandleOffset: CGFloat = 0
@@ -28,6 +30,7 @@ final class VideoViewModel {
     let playerController = PlayerController()
     
     private let trimController = TrimController()
+    
     private let compositionBuilder = CompositionBuilder()
     
     /// TODO: 테스트 용도, 추후 삭제
@@ -152,6 +155,7 @@ final class VideoViewModel {
             
             if case .segmentsUpdated(let updatedSegments) = result {
                 segments = updatedSegments
+            
                 await rebuildPlayerItem()
             }
         } catch {


### PR DESCRIPTION
## 🐱 **작업한 내용, 스크린샷**
1. Track Ruler 메인 간격을 10초에서 5초로 변경합니다.
2. 영상 시작시 Track이 자동으로 움직이지 않는 버그를 수정합니다.
3. Dragging시 프레임 드랍 현상을 완화했습니다.
영상 실행/정지 시 play, pause를 하지 않고 rate를 줄입니다.
play, pause를 할 경우 영상 파이프라인에서 전체적인 구조가 변경되기에 리소스가 많이 듭니다.
```swift
    /// 재생을 시작합니다.
    func play() {
        player.rate = 1
        isPlaying = true
    }
    
    /// 재생을 일시정지합니다.
    func pause() {
        player.rate = 0
        isPlaying = false
    }
```

영상 역재생 시 프레임 드랍 현상을 tolarance 조정을 통해 드랍 현상을 완하합니다.
```swift
    /// 지정된 시간으로 플레이헤드를 이동시킵니다.
    ///
    /// - Parameters:
    ///   - time: 이동할 대상 시간.
    ///   - isDragging: 사용자가 타임라인을 드래그하는 중인지 여부.
    ///                 `true`일 경우, 성능 최적화를 위해 탐색 허용 오차를 사용합니다.
    func seek(to time: CMTime, direction: DragDirection = .none) {
        // 역방향 드래그일 때만 tolerance를 적용하고, 그 외에는 정확한 위치로 이동
        let tolerance = (
            direction == .backward
        ) ? CMTime(
            seconds: 0.5,
            preferredTimescale: 600
        ) : .zero
        
        player.seek(
            to: time,
            toleranceBefore: tolerance,
            toleranceAfter: tolerance
        )
    }
```

### 결과 화면
https://github.com/user-attachments/assets/65c51263-e87c-4e27-8783-45b80de4e73f


