### PR TITLE
fix: trimming 직후 export에서 발생 오류 수정

### DIFF
--- a/HongAndJerry/Visemble/Source/Feature/VideoEditor/ViewModel/EditorViewModel.swift
+++ b/HongAndJerry/Visemble/Source/Feature/VideoEditor/ViewModel/EditorViewModel.swift
@@ -239,7 +239,14 @@ final class EditorViewModel {
       state = .editing
 
     case .requestExport:
-      showExportConfirmAlert = true
+      if selectedSegmentID != nil {
+        Task {
+          await deactivateTrimming()
+          showExportConfirmAlert = true
+        }
+      } else {
+        showExportConfirmAlert = true
+      }
     case .handleExport(let router):
       handleExport(router: router)
     case .handleAlertDismiss(let router):


### PR DESCRIPTION
## 🐱 **작업한 내용, 스크린샷**
- trimming 직후 export 시 핸들로 조절한 구간이 적용되지 않는 문제 발생
- export 버튼을 탭하여 alert를 보여주기 전에 deactivateTrimming() 호출하여 구간을 적용

resolved #69 